### PR TITLE
Fix Typo in HTML Strong Tag 

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -13,7 +13,7 @@ Welcome to Codédex's GitHub! ⚡️ Codédex is the brand new way to learn to c
 Journey through the fantasy land of Python, HTML/CSS, JS, React, SQL, Git & GitHub, or Command Line, earn experience points (XP) to unlock new regions, and collect all the badges at your own pace. 👩🏾‍💻👨🏻‍💻👩🏼‍💻
 
 <br /><br />
-<strong>Start your coding adventure ⋆˙⟡ <strong />
+<strong>Start your coding adventure ⋆˙⟡ </strong>
 </p>
 
 


### PR DESCRIPTION
This pull request addresses a typo in the HTML content by correcting the closing <strong> tag from <strong /> to </strong>