### PR TITLE
fix: image size & missing quotation marks

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,7 +8,7 @@
  
 </p>
 <h1>Codédex on GitHub</h1>
-  <img align=right src="https://github.com/codedex-io/.github/assets/65576812/c52c79df-d10d-412e-b0ef-ec0b969d2a5d" width="230px">
+  <img align="right" src="https://github.com/codedex-io/.github/assets/65576812/c52c79df-d10d-412e-b0ef-ec0b969d2a5d" width="230px">
 Welcome to Codédex's GitHub! ⚡️ Codédex is the brand new way to learn to code for Gen Z.
 Journey through the fantasy land of Python, HTML/CSS, JS, React, SQL, Git & GitHub, or Command Line, earn experience points (XP) to unlock new regions, and collect all the badges at your own pace. 👩🏾‍💻👨🏻‍💻👩🏼‍💻
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -8,7 +8,7 @@
  
 </p>
 <h1>Codédex on GitHub</h1>
-  <img align="right" src="https://github.com/codedex-io/.github/assets/65576812/c52c79df-d10d-412e-b0ef-ec0b969d2a5d" width="230px">
+  <img align="right" src="https://github.com/codedex-io/.github/assets/65576812/c52c79df-d10d-412e-b0ef-ec0b969d2a5d" width="30%">
 Welcome to Codédex's GitHub! ⚡️ Codédex is the brand new way to learn to code for Gen Z.
 Journey through the fantasy land of Python, HTML/CSS, JS, React, SQL, Git & GitHub, or Command Line, earn experience points (XP) to unlock new regions, and collect all the badges at your own pace. 👩🏾‍💻👨🏻‍💻👩🏼‍💻
 


### PR DESCRIPTION
This PR addresses the following:

1. too large image size on smaller devices, making text difficult to read

**BEFORE**

![photo_2024-10-31_18-41-11](https://github.com/user-attachments/assets/b1116eb0-c4d6-417d-9dc2-be82fad4a3c4)

**AFTER**

![photo_2024-10-31_18-41-04](https://github.com/user-attachments/assets/f4df0b3f-f73d-4a87-bc5d-2935b88bf471)

2. missing quotation marks for `align`
